### PR TITLE
スケジュールワークフローを再有効化

### DIFF
--- a/.github/workflows/stock_monitor.yml
+++ b/.github/workflows/stock_monitor.yml
@@ -3,7 +3,8 @@ name: CI Medical Stock Monitor
 on:
   schedule:
     # 毎時間実行 (UTC)
-    - cron:  '0 * * * *'
+    # 注意: 60日以上アクティビティがないとGitHubにより自動無効化されます
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- GitHubによる非アクティブリポジトリの自動無効化に関するコメントを追加
- cron式のフォーマットを整理

https://claude.ai/code/session_01TpRKBVJR4VUvcDqfNWZg4h